### PR TITLE
don't use strum_macros directly, use strum with derive feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,7 @@ version = "0.8.3"
 chrono = "0.4.38"
 regex = "1.10.4"
 roxmltree = "0.19.0"
-strum = "0.26.2"
-strum_macros = "0.26.2"
+strum = { version = "0.26", features = ["derive"] }
 time = { version = "0.3.36" }
 url = "2.5.0"
 

--- a/src/itunes.rs
+++ b/src/itunes.rs
@@ -1,7 +1,7 @@
 use crate::strings::Url;
 use crate::utils;
 use crate::Other;
-use strum_macros::EnumIter;
+use strum::EnumIter;
 
 mod category;
 pub use category::{CategoryName, SubcategoryName};

--- a/src/itunes/category.rs
+++ b/src/itunes/category.rs
@@ -2,8 +2,7 @@ use crate::utils;
 use crate::Other;
 use std::fmt;
 use std::str::FromStr;
-use strum::EnumProperty;
-use strum_macros::{EnumIter, EnumProperty};
+use strum::{EnumIter, EnumProperty};
 
 /// Apple Podcasts podcast category names.
 #[derive(Debug, PartialEq, Eq, EnumProperty, EnumIter)]

--- a/src/language.rs
+++ b/src/language.rs
@@ -1,7 +1,6 @@
 use crate::Other;
 use std::str::FromStr;
-use strum::{EnumProperty, IntoEnumIterator};
-use strum_macros::{Display, EnumIter, EnumProperty, EnumString};
+use strum::{Display, EnumIter, EnumProperty, EnumString, IntoEnumIterator};
 
 /// Used for deserializing languages.
 ///

--- a/src/mime.rs
+++ b/src/mime.rs
@@ -1,7 +1,6 @@
 use crate::utils;
 use crate::Other;
-use strum::EnumProperty;
-use strum_macros::{EnumIter, EnumProperty};
+use strum::{EnumIter, EnumProperty};
 
 /// Used for deserializing mime types of enclosures.
 #[derive(Debug, PartialEq, Eq, EnumProperty, EnumIter)]

--- a/src/podcast/alternate_enclosure.rs
+++ b/src/podcast/alternate_enclosure.rs
@@ -1,7 +1,6 @@
 use crate::utils;
 use crate::Other;
-use strum::EnumProperty;
-use strum_macros::{EnumIter, EnumProperty};
+use strum::{EnumIter, EnumProperty};
 
 /// Type of [Integrity](crate::podcast::Integrity).
 #[derive(Debug, PartialEq, Eq, EnumProperty, EnumIter)]

--- a/src/podcast/block.rs
+++ b/src/podcast/block.rs
@@ -1,6 +1,6 @@
 use crate::utils;
 use crate::Other;
-use strum_macros::EnumIter;
+use strum::EnumIter;
 
 /// Podcast platforms.
 ///

--- a/src/podcast/license.rs
+++ b/src/podcast/license.rs
@@ -1,7 +1,6 @@
 use crate::utils;
 use crate::Other;
-use strum::EnumProperty;
-use strum_macros::{EnumIter, EnumProperty};
+use strum::{EnumIter, EnumProperty};
 
 /// Type of [License](crate::podcast::License).
 #[derive(Debug, PartialEq, Eq, EnumProperty, EnumIter)]

--- a/src/podcast/live_item.rs
+++ b/src/podcast/live_item.rs
@@ -1,6 +1,6 @@
 use crate::utils;
 use crate::Other;
-use strum_macros::EnumIter;
+use strum::EnumIter;
 
 /// Status of [LiveItem](crate::podcast::LiveItem).
 #[derive(Debug, PartialEq, Eq, EnumIter)]

--- a/src/podcast/location.rs
+++ b/src/podcast/location.rs
@@ -1,6 +1,6 @@
 use crate::basic::{Float, NumberConstraint};
 use crate::Other;
-use strum_macros::{Display, EnumString};
+use strum::{Display, EnumString};
 
 /// Geographical coordinates.
 #[derive(Debug, PartialEq, Clone)]

--- a/src/podcast/medium.rs
+++ b/src/podcast/medium.rs
@@ -1,6 +1,6 @@
 use crate::utils;
 use crate::Other;
-use strum_macros::EnumIter;
+use strum::EnumIter;
 
 /// Medium of the feed.
 #[derive(Debug, PartialEq, Eq, EnumIter)]

--- a/src/podcast/person.rs
+++ b/src/podcast/person.rs
@@ -1,7 +1,6 @@
 use crate::utils;
 use crate::Other;
-use strum::EnumProperty;
-use strum_macros::{EnumIter, EnumProperty};
+use strum::{EnumIter, EnumProperty};
 
 /// Group (as defined by [Podcast Taxonomy Project](https://podcasttaxonomy.com)) of [Person](crate::podcast::Person).
 #[derive(Debug, PartialEq, Eq, EnumProperty, EnumIter)]

--- a/src/podcast/social_interact.rs
+++ b/src/podcast/social_interact.rs
@@ -1,6 +1,6 @@
 use crate::utils;
 use crate::Other;
-use strum_macros::EnumIter;
+use strum::EnumIter;
 
 /// Social protocols that can be used in [SocialInteract](crate::podcast::SocialInteract).
 #[derive(Debug, PartialEq, Eq, EnumIter)]

--- a/src/podcast/transcript.rs
+++ b/src/podcast/transcript.rs
@@ -1,6 +1,6 @@
 use crate::utils;
 use crate::Other;
-use strum_macros::EnumIter;
+use strum::EnumIter;
 
 /// Used for deserializing `rel` attribute of [Transcript](crate::podcast::Transcript).
 #[derive(Debug, PartialEq, Eq, EnumIter)]

--- a/src/podcast/txt.rs
+++ b/src/podcast/txt.rs
@@ -1,6 +1,6 @@
 use crate::utils;
 use crate::Other;
-use strum_macros::EnumIter;
+use strum::EnumIter;
 
 /// Allowed purposes for [Txt](crate::podcast::Txt).
 #[derive(Debug, PartialEq, Eq, EnumIter)]

--- a/src/podcast/value.rs
+++ b/src/podcast/value.rs
@@ -1,6 +1,6 @@
 use crate::utils;
 use crate::Other;
-use strum_macros::EnumIter;
+use strum::EnumIter;
 
 /// Type of [Value](crate::podcast::Value).
 #[derive(Debug, PartialEq, Eq, EnumIter)]


### PR DESCRIPTION
The macros in the strum crate can be used either throught the strum derive feature or directly through the strum_macros crate. The problem is that the macro namespace is global and when two crates use strum differently (one through strum_macros, one through the derive feature), the strum macros will conflict and cause build errors.

In order to make badpod usable with other crates that use strum, this PR switches over to strum with the derive feature as this is the recommended way by the strum crate.

See also:
https://github.com/Peternator7/strum/issues/172
https://github.com/Peternator7/strum/issues/362